### PR TITLE
Defect fix with follow for linked entities

### DIFF
--- a/lib/SirenHelpers.js
+++ b/lib/SirenHelpers.js
@@ -17,7 +17,7 @@ function follow(rel) {
 			throw new Error('No link found for provided rel', {rel});
 		}
 
-		return link.follow();
+		return typeof link === 'string' ? Siren.get(link) : link.follow();
 	};
 }
 


### PR DESCRIPTION
Fixed issue with follow when encountering a linked entity since that will simply return the href string from the entity and therefore 'link.follow()' throws an error.
